### PR TITLE
WooCommerce: Adjusted Folder Structure on build

### DIFF
--- a/build
+++ b/build
@@ -31,5 +31,14 @@ build_plugin() {
   # Note: CMS upload dir might not exist during CI build
   if [ -d $TARGET_DIR/upload ]; then
     cp -Lr $TARGET_DIR/plugin/* $TARGET_DIR/upload
+
+    # Release(WooCommerce): move contents of indodana-payment
+    # directly under plugin dir before zipped
+    if [ -z "${PLUGIN_NAME##woocommerce*}" ]; then
+      mkdir $TARGET_DIR/temp
+      cp -Lr $TARGET_DIR/plugin/wp-content/plugins/indodana-payment/* $TARGET_DIR/temp
+      rm -rf $TARGET_DIR/plugin
+      mv $TARGET_DIR/temp $TARGET_DIR/plugin
+    fi
   fi
 }


### PR DESCRIPTION
Adjusted folder structure on build before zipped for release for WooCommerce

| `Before`  | `After`  |
|---|---|
| <img src="https://user-images.githubusercontent.com/98730874/155253372-c9e2c7dd-8457-47d7-bdbe-2acdfc5383ea.png" width="300" /> | <img src="https://user-images.githubusercontent.com/98730874/155254049-934f8226-26dd-4b95-9b9d-8e768065239b.png" width="300" /> |