### PR TITLE
ci: Upgrade retired GitHub Actions so workflows can run again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
     - name: Clone repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     # Install & cache environments
     # https://github.com/marketplace/actions/setup-php-action#cache-extensions
@@ -37,7 +37,7 @@ jobs:
         key: ${{ env.key }}
 
     - name: Cache extensions
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: ${{ steps.cache-env.outputs.dir }}
         key: ${{ steps.cache-env.outputs.key }}
@@ -59,10 +59,10 @@ jobs:
     - name: Get composer cache directory
       id: composer-cache
       working-directory: ${{ env.working-directory }}
-      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
     - name: Cache dependencies
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: ${{ steps.composer-cache.outputs.dir }}
         key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout the project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # Use semantic versioning. Example output: 1.0.0
       - name: Get package version
@@ -155,7 +155,7 @@ jobs:
           key: ${{ env.key }}
 
       - name: Cache extensions
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ${{ steps.cache-env.outputs.dir }}
           key: ${{ steps.cache-env.outputs.key }}
@@ -184,7 +184,7 @@ jobs:
           zip -r ${{ env.release-name }}.zip plugin
 
       - name: Create the release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: ${{ env.target-directory }}/${{ env.release-name }}.zip
         env:


### PR DESCRIPTION
## Problem

Every job in this repo currently fails in ~3 seconds during **Set up job**, before a single step runs:

> `##[error]This request has been automatically failed because it uses a deprecated version of actions/cache: v1.`

GitHub disabled `actions/cache@v1` service-side. This is a rejection, not a warning — no workflow logic below it executes.

Consequences:
- CI is red on every PR regardless of content (see the red checks on #60 and #61)
- **A release tag push produces an instantly-failed run instead of a plugin zip.** The last tag here, `MagentoV2-1.0.2`, predates the closure, so nothing exercised `release.yml` after it broke.

## Changes

| Action | From | To | Why |
|---|---|---|---|
| `actions/cache` | v1 | v4 | Retired service-side — the actual blocker. `release.yml` ×1, `ci.yml` ×2 |
| `actions/checkout` | v2 | v4 | Node 16 runtime, force-migrated by GitHub |
| `softprops/action-gh-release` | v1 | v2 | Same |
| `::set-output` | — | `$GITHUB_OUTPUT` | The `set-output` workflow command was also retired (`ci.yml:62`) |

Inputs are unchanged: `actions/cache@v4` takes the same `path` / `key` / `restore-keys` this workflow already passes, so cache behaviour is identical apart from a new cache namespace.

Deliberately left alone: `shivammathur/setup-php@v2` and `shivammathur/cache-extensions@v1` are both current majors, and `olegtarasov/get-tag@v2.1` still functions.

## Verification

- Both workflows re-parsed as valid YAML
- No `cache@v1`, `checkout@v2`, `gh-release@v1`, or `set-output` left anywhere in `.github/workflows/`
- The real proof is this PR's own CI run — it should now get past **Set up job** and actually execute the PHP 5.6 test suite for `packages/common`. I'll report what it does, including whether anything downstream fails once the jobs can finally run.

## Notes

Two things I did **not** touch, to keep this focused on the blocker:
- `ci.yml:73` passes `--no-suggest` to `composer install`, an option Composer 2 dropped. If the job now gets far enough to fail there, that's the next fix.
- `packages/common` is only tested on PHP **5.6**, while `magentov2.4.4` targets PHP 8.1–8.3. Adding 8.1 to that matrix would be worth a follow-up.

Merge order: this should land **before** #60 and #61 so both get green checks and the release workflow is functional by the time `MagentoV2.4.4-1.0.0` is tagged.