### PR TITLE
fix: Bump SDK to 2.0.1 to stop calling the deprecated payment_calculation API

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,11 +159,6 @@ jobs:
           echo 'source-directory=magentov2.4.4' >> $GITHUB_ENV
           echo 'target-directory=.build/magentov2.4.4' >> $GITHUB_ENV
           echo 'build-command=make magentov2.4.4-build' >> $GITHUB_ENV
-          # indodana/indodana-paylater-sdk 2.0.0 declares "php": "^5.6|^7.0", so
-          # composer refuses to install it on the PHP 8.1 this plugin targets.
-          # The SDK code itself is PHP 8 compatible (see the ^8.0 constraint on
-          # SDK 2.1.0-BETA); drop this once the pin in packages/common is raised.
-          echo 'composer-flags=--ignore-platform-req=php' >> $GITHUB_ENV
           echo "release-title=Magento 2.4.4 - 2.4.8 (PHP 8.1+) | plugin ${PACKAGE_VERSION}" >> $GITHUB_ENV
           {
             echo 'release-notes<<RELEASE_NOTES_EOF'
@@ -224,10 +219,9 @@ jobs:
         working-directory: ${{ env.source-directory }}
         run: composer validate
 
-      # composer-flags is empty for every plugin that does not set it
       - name: Install plugin dependencies
         working-directory: ${{ env.source-directory }}
-        run: composer install --prefer-dist --no-progress ${{ env.composer-flags }}
+        run: composer install --prefer-dist --no-progress
 
       - name: Build the plugin
         run: ${{ env.build-command }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,6 +159,11 @@ jobs:
           echo 'source-directory=magentov2.4.4' >> $GITHUB_ENV
           echo 'target-directory=.build/magentov2.4.4' >> $GITHUB_ENV
           echo 'build-command=make magentov2.4.4-build' >> $GITHUB_ENV
+          # indodana/indodana-paylater-sdk 2.0.0 declares "php": "^5.6|^7.0", so
+          # composer refuses to install it on the PHP 8.1 this plugin targets.
+          # The SDK code itself is PHP 8 compatible (see the ^8.0 constraint on
+          # SDK 2.1.0-BETA); drop this once the pin in packages/common is raised.
+          echo 'composer-flags=--ignore-platform-req=php' >> $GITHUB_ENV
           echo "release-title=Magento 2.4.4 - 2.4.8 (PHP 8.1+) | plugin ${PACKAGE_VERSION}" >> $GITHUB_ENV
           {
             echo 'release-notes<<RELEASE_NOTES_EOF'
@@ -219,9 +224,10 @@ jobs:
         working-directory: ${{ env.source-directory }}
         run: composer validate
 
+      # composer-flags is empty for every plugin that does not set it
       - name: Install plugin dependencies
         working-directory: ${{ env.source-directory }}
-        run: composer install --prefer-dist --no-progress
+        run: composer install --prefer-dist --no-progress ${{ env.composer-flags }}
 
       - name: Build the plugin
         run: ${{ env.build-command }}

--- a/magento1/composer.lock
+++ b/magento1/composer.lock
@@ -12,10 +12,10 @@
             "dist": {
                 "type": "path",
                 "url": "../packages/common",
-                "reference": "63467d6577f91d902652d15185c998a9bc39fd2f"
+                "reference": "a5e57c150a5bc04ccfd2b46fed5e1f516fdde528"
             },
             "require": {
-                "indodana/indodana-paylater-sdk": "2.1.0",
+                "indodana/indodana-paylater-sdk": "2.0.1",
                 "respect/validation": "^1.1"
             },
             "require-dev": {
@@ -52,27 +52,26 @@
         },
         {
             "name": "indodana/indodana-paylater-sdk",
-            "version": "2.1.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/indodana-finance/indodana-paylater-sdk-php.git",
-                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f"
+                "reference": "055437ff32f78cc37dee4ae73156feaddb83880a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/indodana-finance/indodana-paylater-sdk-php/zipball/89f6f68885b0162c25f4c1048e1d1932cee9275f",
-                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f",
+                "url": "https://api.github.com/repos/indodana-finance/indodana-paylater-sdk-php/zipball/055437ff32f78cc37dee4ae73156feaddb83880a",
+                "reference": "055437ff32f78cc37dee4ae73156feaddb83880a",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6|^7.0|^8.0"
+                "php": "^5.6|^7.0",
+                "respect/validation": "^1.1"
             },
             "require-dev": {
                 "mockery/mockery": "^1.3",
                 "php-mock/php-mock-mockery": "^1.3",
-                "phpcompatibility/php-compatibility": "^9.3",
-                "phpunit/phpunit": "^5",
-                "squizlabs/php_codesniffer": "^3.6"
+                "phpunit/phpunit": "^5"
             },
             "type": "library",
             "autoload": {
@@ -94,9 +93,9 @@
             "description": "Indodana Paylater SDK for PHP that provides merchant integration functionalities",
             "support": {
                 "issues": "https://github.com/indodana-finance/indodana-paylater-sdk-php/issues",
-                "source": "https://github.com/indodana-finance/indodana-paylater-sdk-php/tree/2.1.0"
+                "source": "https://github.com/indodana-finance/indodana-paylater-sdk-php/tree/2.0.1"
             },
-            "time": "2026-08-14T06:37:44+00:00"
+            "time": "2026-08-14T06:53:39+00:00"
         },
         {
             "name": "respect/validation",

--- a/magento1/composer.lock
+++ b/magento1/composer.lock
@@ -8,14 +8,14 @@
     "packages": [
         {
             "name": "indodana/indodana-paylater-ecommerce-common",
-            "version": "dev-master",
+            "version": "dev-bump_sdk_2_1_0_deprecated_api_fix",
             "dist": {
                 "type": "path",
                 "url": "../packages/common",
-                "reference": "0e7294464d80e5e153860560014fc0873ef03090"
+                "reference": "63467d6577f91d902652d15185c998a9bc39fd2f"
             },
             "require": {
-                "indodana/indodana-paylater-sdk": "2.0.0",
+                "indodana/indodana-paylater-sdk": "2.1.0",
                 "respect/validation": "^1.1"
             },
             "require-dev": {
@@ -52,26 +52,27 @@
         },
         {
             "name": "indodana/indodana-paylater-sdk",
-            "version": "2.0.0",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/indodana/indodana-paylater-sdk-php.git",
-                "reference": "f9c044406fa0b34ecec84cbcd2e070d566768ccb"
+                "url": "https://github.com/indodana-finance/indodana-paylater-sdk-php.git",
+                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/indodana/indodana-paylater-sdk-php/zipball/f9c044406fa0b34ecec84cbcd2e070d566768ccb",
-                "reference": "f9c044406fa0b34ecec84cbcd2e070d566768ccb",
+                "url": "https://api.github.com/repos/indodana-finance/indodana-paylater-sdk-php/zipball/89f6f68885b0162c25f4c1048e1d1932cee9275f",
+                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6|^7.0",
-                "respect/validation": "^1.1"
+                "php": "^5.6|^7.0|^8.0"
             },
             "require-dev": {
                 "mockery/mockery": "^1.3",
                 "php-mock/php-mock-mockery": "^1.3",
-                "phpunit/phpunit": "^5"
+                "phpcompatibility/php-compatibility": "^9.3",
+                "phpunit/phpunit": "^5",
+                "squizlabs/php_codesniffer": "^3.6"
             },
             "type": "library",
             "autoload": {
@@ -91,7 +92,11 @@
                 }
             ],
             "description": "Indodana Paylater SDK for PHP that provides merchant integration functionalities",
-            "time": "2020-08-25T12:57:34+00:00"
+            "support": {
+                "issues": "https://github.com/indodana-finance/indodana-paylater-sdk-php/issues",
+                "source": "https://github.com/indodana-finance/indodana-paylater-sdk-php/tree/2.1.0"
+            },
+            "time": "2026-08-14T06:37:44+00:00"
         },
         {
             "name": "respect/validation",
@@ -309,7 +314,7 @@
     },
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/magentov2.4.0/composer.lock
+++ b/magentov2.4.0/composer.lock
@@ -12,10 +12,10 @@
             "dist": {
                 "type": "path",
                 "url": "../packages/common",
-                "reference": "63467d6577f91d902652d15185c998a9bc39fd2f"
+                "reference": "a5e57c150a5bc04ccfd2b46fed5e1f516fdde528"
             },
             "require": {
-                "indodana/indodana-paylater-sdk": "2.1.0",
+                "indodana/indodana-paylater-sdk": "2.0.1",
                 "respect/validation": "^1.1"
             },
             "require-dev": {
@@ -52,27 +52,26 @@
         },
         {
             "name": "indodana/indodana-paylater-sdk",
-            "version": "2.1.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/indodana-finance/indodana-paylater-sdk-php.git",
-                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f"
+                "reference": "055437ff32f78cc37dee4ae73156feaddb83880a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/indodana-finance/indodana-paylater-sdk-php/zipball/89f6f68885b0162c25f4c1048e1d1932cee9275f",
-                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f",
+                "url": "https://api.github.com/repos/indodana-finance/indodana-paylater-sdk-php/zipball/055437ff32f78cc37dee4ae73156feaddb83880a",
+                "reference": "055437ff32f78cc37dee4ae73156feaddb83880a",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6|^7.0|^8.0"
+                "php": "^5.6|^7.0",
+                "respect/validation": "^1.1"
             },
             "require-dev": {
                 "mockery/mockery": "^1.3",
                 "php-mock/php-mock-mockery": "^1.3",
-                "phpcompatibility/php-compatibility": "^9.3",
-                "phpunit/phpunit": "^5",
-                "squizlabs/php_codesniffer": "^3.6"
+                "phpunit/phpunit": "^5"
             },
             "type": "library",
             "autoload": {
@@ -94,9 +93,9 @@
             "description": "Indodana Paylater SDK for PHP that provides merchant integration functionalities",
             "support": {
                 "issues": "https://github.com/indodana-finance/indodana-paylater-sdk-php/issues",
-                "source": "https://github.com/indodana-finance/indodana-paylater-sdk-php/tree/2.1.0"
+                "source": "https://github.com/indodana-finance/indodana-paylater-sdk-php/tree/2.0.1"
             },
-            "time": "2026-08-14T06:37:44+00:00"
+            "time": "2026-08-14T06:53:39+00:00"
         },
         {
             "name": "respect/validation",

--- a/magentov2.4.0/composer.lock
+++ b/magentov2.4.0/composer.lock
@@ -8,14 +8,14 @@
     "packages": [
         {
             "name": "indodana/indodana-paylater-ecommerce-common",
-            "version": "dev-fix_github_actions_release",
+            "version": "dev-bump_sdk_2_1_0_deprecated_api_fix",
             "dist": {
                 "type": "path",
                 "url": "../packages/common",
-                "reference": "0e7294464d80e5e153860560014fc0873ef03090"
+                "reference": "63467d6577f91d902652d15185c998a9bc39fd2f"
             },
             "require": {
-                "indodana/indodana-paylater-sdk": "2.0.0",
+                "indodana/indodana-paylater-sdk": "2.1.0",
                 "respect/validation": "^1.1"
             },
             "require-dev": {
@@ -52,26 +52,27 @@
         },
         {
             "name": "indodana/indodana-paylater-sdk",
-            "version": "2.0.0",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/indodana/indodana-paylater-sdk-php.git",
-                "reference": "f9c044406fa0b34ecec84cbcd2e070d566768ccb"
+                "url": "https://github.com/indodana-finance/indodana-paylater-sdk-php.git",
+                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/indodana/indodana-paylater-sdk-php/zipball/f9c044406fa0b34ecec84cbcd2e070d566768ccb",
-                "reference": "f9c044406fa0b34ecec84cbcd2e070d566768ccb",
+                "url": "https://api.github.com/repos/indodana-finance/indodana-paylater-sdk-php/zipball/89f6f68885b0162c25f4c1048e1d1932cee9275f",
+                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6|^7.0",
-                "respect/validation": "^1.1"
+                "php": "^5.6|^7.0|^8.0"
             },
             "require-dev": {
                 "mockery/mockery": "^1.3",
                 "php-mock/php-mock-mockery": "^1.3",
-                "phpunit/phpunit": "^5"
+                "phpcompatibility/php-compatibility": "^9.3",
+                "phpunit/phpunit": "^5",
+                "squizlabs/php_codesniffer": "^3.6"
             },
             "type": "library",
             "autoload": {
@@ -91,7 +92,11 @@
                 }
             ],
             "description": "Indodana Paylater SDK for PHP that provides merchant integration functionalities",
-            "time": "2020-08-25T12:57:34+00:00"
+            "support": {
+                "issues": "https://github.com/indodana-finance/indodana-paylater-sdk-php/issues",
+                "source": "https://github.com/indodana-finance/indodana-paylater-sdk-php/tree/2.1.0"
+            },
+            "time": "2026-08-14T06:37:44+00:00"
         },
         {
             "name": "respect/validation",
@@ -245,7 +250,7 @@
     },
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/magentov2.4.4/composer.lock
+++ b/magentov2.4.4/composer.lock
@@ -12,10 +12,10 @@
             "dist": {
                 "type": "path",
                 "url": "../packages/common",
-                "reference": "63467d6577f91d902652d15185c998a9bc39fd2f"
+                "reference": "a5e57c150a5bc04ccfd2b46fed5e1f516fdde528"
             },
             "require": {
-                "indodana/indodana-paylater-sdk": "2.1.0",
+                "indodana/indodana-paylater-sdk": "2.0.1",
                 "respect/validation": "^1.1"
             },
             "require-dev": {
@@ -52,27 +52,26 @@
         },
         {
             "name": "indodana/indodana-paylater-sdk",
-            "version": "2.1.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/indodana-finance/indodana-paylater-sdk-php.git",
-                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f"
+                "reference": "055437ff32f78cc37dee4ae73156feaddb83880a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/indodana-finance/indodana-paylater-sdk-php/zipball/89f6f68885b0162c25f4c1048e1d1932cee9275f",
-                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f",
+                "url": "https://api.github.com/repos/indodana-finance/indodana-paylater-sdk-php/zipball/055437ff32f78cc37dee4ae73156feaddb83880a",
+                "reference": "055437ff32f78cc37dee4ae73156feaddb83880a",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6|^7.0|^8.0"
+                "php": "^5.6|^7.0",
+                "respect/validation": "^1.1"
             },
             "require-dev": {
                 "mockery/mockery": "^1.3",
                 "php-mock/php-mock-mockery": "^1.3",
-                "phpcompatibility/php-compatibility": "^9.3",
-                "phpunit/phpunit": "^5",
-                "squizlabs/php_codesniffer": "^3.6"
+                "phpunit/phpunit": "^5"
             },
             "type": "library",
             "autoload": {
@@ -94,9 +93,9 @@
             "description": "Indodana Paylater SDK for PHP that provides merchant integration functionalities",
             "support": {
                 "issues": "https://github.com/indodana-finance/indodana-paylater-sdk-php/issues",
-                "source": "https://github.com/indodana-finance/indodana-paylater-sdk-php/tree/2.1.0"
+                "source": "https://github.com/indodana-finance/indodana-paylater-sdk-php/tree/2.0.1"
             },
-            "time": "2026-08-14T06:37:44+00:00"
+            "time": "2026-08-14T06:53:39+00:00"
         },
         {
             "name": "respect/validation",

--- a/magentov2.4.4/composer.lock
+++ b/magentov2.4.4/composer.lock
@@ -8,14 +8,14 @@
     "packages": [
         {
             "name": "indodana/indodana-paylater-ecommerce-common",
-            "version": "dev-fix_github_actions_release",
+            "version": "dev-bump_sdk_2_1_0_deprecated_api_fix",
             "dist": {
                 "type": "path",
                 "url": "../packages/common",
-                "reference": "0e7294464d80e5e153860560014fc0873ef03090"
+                "reference": "63467d6577f91d902652d15185c998a9bc39fd2f"
             },
             "require": {
-                "indodana/indodana-paylater-sdk": "2.0.0",
+                "indodana/indodana-paylater-sdk": "2.1.0",
                 "respect/validation": "^1.1"
             },
             "require-dev": {
@@ -52,26 +52,27 @@
         },
         {
             "name": "indodana/indodana-paylater-sdk",
-            "version": "2.0.0",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/indodana/indodana-paylater-sdk-php.git",
-                "reference": "f9c044406fa0b34ecec84cbcd2e070d566768ccb"
+                "url": "https://github.com/indodana-finance/indodana-paylater-sdk-php.git",
+                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/indodana/indodana-paylater-sdk-php/zipball/f9c044406fa0b34ecec84cbcd2e070d566768ccb",
-                "reference": "f9c044406fa0b34ecec84cbcd2e070d566768ccb",
+                "url": "https://api.github.com/repos/indodana-finance/indodana-paylater-sdk-php/zipball/89f6f68885b0162c25f4c1048e1d1932cee9275f",
+                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6|^7.0",
-                "respect/validation": "^1.1"
+                "php": "^5.6|^7.0|^8.0"
             },
             "require-dev": {
                 "mockery/mockery": "^1.3",
                 "php-mock/php-mock-mockery": "^1.3",
-                "phpunit/phpunit": "^5"
+                "phpcompatibility/php-compatibility": "^9.3",
+                "phpunit/phpunit": "^5",
+                "squizlabs/php_codesniffer": "^3.6"
             },
             "type": "library",
             "autoload": {
@@ -91,7 +92,11 @@
                 }
             ],
             "description": "Indodana Paylater SDK for PHP that provides merchant integration functionalities",
-            "time": "2020-08-25T12:57:34+00:00"
+            "support": {
+                "issues": "https://github.com/indodana-finance/indodana-paylater-sdk-php/issues",
+                "source": "https://github.com/indodana-finance/indodana-paylater-sdk-php/tree/2.1.0"
+            },
+            "time": "2026-08-14T06:37:44+00:00"
         },
         {
             "name": "respect/validation",
@@ -245,7 +250,7 @@
     },
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/opencartv1/composer.lock
+++ b/opencartv1/composer.lock
@@ -12,10 +12,10 @@
             "dist": {
                 "type": "path",
                 "url": "../packages/common",
-                "reference": "63467d6577f91d902652d15185c998a9bc39fd2f"
+                "reference": "a5e57c150a5bc04ccfd2b46fed5e1f516fdde528"
             },
             "require": {
-                "indodana/indodana-paylater-sdk": "2.1.0",
+                "indodana/indodana-paylater-sdk": "2.0.1",
                 "respect/validation": "^1.1"
             },
             "require-dev": {
@@ -52,27 +52,26 @@
         },
         {
             "name": "indodana/indodana-paylater-sdk",
-            "version": "2.1.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/indodana-finance/indodana-paylater-sdk-php.git",
-                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f"
+                "reference": "055437ff32f78cc37dee4ae73156feaddb83880a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/indodana-finance/indodana-paylater-sdk-php/zipball/89f6f68885b0162c25f4c1048e1d1932cee9275f",
-                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f",
+                "url": "https://api.github.com/repos/indodana-finance/indodana-paylater-sdk-php/zipball/055437ff32f78cc37dee4ae73156feaddb83880a",
+                "reference": "055437ff32f78cc37dee4ae73156feaddb83880a",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6|^7.0|^8.0"
+                "php": "^5.6|^7.0",
+                "respect/validation": "^1.1"
             },
             "require-dev": {
                 "mockery/mockery": "^1.3",
                 "php-mock/php-mock-mockery": "^1.3",
-                "phpcompatibility/php-compatibility": "^9.3",
-                "phpunit/phpunit": "^5",
-                "squizlabs/php_codesniffer": "^3.6"
+                "phpunit/phpunit": "^5"
             },
             "type": "library",
             "autoload": {
@@ -94,9 +93,9 @@
             "description": "Indodana Paylater SDK for PHP that provides merchant integration functionalities",
             "support": {
                 "issues": "https://github.com/indodana-finance/indodana-paylater-sdk-php/issues",
-                "source": "https://github.com/indodana-finance/indodana-paylater-sdk-php/tree/2.1.0"
+                "source": "https://github.com/indodana-finance/indodana-paylater-sdk-php/tree/2.0.1"
             },
-            "time": "2026-08-14T06:37:44+00:00"
+            "time": "2026-08-14T06:53:39+00:00"
         },
         {
             "name": "respect/validation",

--- a/opencartv1/composer.lock
+++ b/opencartv1/composer.lock
@@ -8,14 +8,14 @@
     "packages": [
         {
             "name": "indodana/indodana-paylater-ecommerce-common",
-            "version": "dev-master",
+            "version": "dev-bump_sdk_2_1_0_deprecated_api_fix",
             "dist": {
                 "type": "path",
                 "url": "../packages/common",
-                "reference": "0e7294464d80e5e153860560014fc0873ef03090"
+                "reference": "63467d6577f91d902652d15185c998a9bc39fd2f"
             },
             "require": {
-                "indodana/indodana-paylater-sdk": "2.0.0",
+                "indodana/indodana-paylater-sdk": "2.1.0",
                 "respect/validation": "^1.1"
             },
             "require-dev": {
@@ -52,26 +52,27 @@
         },
         {
             "name": "indodana/indodana-paylater-sdk",
-            "version": "2.0.0",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/indodana/indodana-paylater-sdk-php.git",
-                "reference": "f9c044406fa0b34ecec84cbcd2e070d566768ccb"
+                "url": "https://github.com/indodana-finance/indodana-paylater-sdk-php.git",
+                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/indodana/indodana-paylater-sdk-php/zipball/f9c044406fa0b34ecec84cbcd2e070d566768ccb",
-                "reference": "f9c044406fa0b34ecec84cbcd2e070d566768ccb",
+                "url": "https://api.github.com/repos/indodana-finance/indodana-paylater-sdk-php/zipball/89f6f68885b0162c25f4c1048e1d1932cee9275f",
+                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6|^7.0",
-                "respect/validation": "^1.1"
+                "php": "^5.6|^7.0|^8.0"
             },
             "require-dev": {
                 "mockery/mockery": "^1.3",
                 "php-mock/php-mock-mockery": "^1.3",
-                "phpunit/phpunit": "^5"
+                "phpcompatibility/php-compatibility": "^9.3",
+                "phpunit/phpunit": "^5",
+                "squizlabs/php_codesniffer": "^3.6"
             },
             "type": "library",
             "autoload": {
@@ -91,7 +92,11 @@
                 }
             ],
             "description": "Indodana Paylater SDK for PHP that provides merchant integration functionalities",
-            "time": "2020-08-25T12:57:34+00:00"
+            "support": {
+                "issues": "https://github.com/indodana-finance/indodana-paylater-sdk-php/issues",
+                "source": "https://github.com/indodana-finance/indodana-paylater-sdk-php/tree/2.1.0"
+            },
+            "time": "2026-08-14T06:37:44+00:00"
         },
         {
             "name": "respect/validation",
@@ -309,7 +314,7 @@
     },
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/opencartv2.3/composer.lock
+++ b/opencartv2.3/composer.lock
@@ -12,10 +12,10 @@
             "dist": {
                 "type": "path",
                 "url": "../packages/common",
-                "reference": "63467d6577f91d902652d15185c998a9bc39fd2f"
+                "reference": "a5e57c150a5bc04ccfd2b46fed5e1f516fdde528"
             },
             "require": {
-                "indodana/indodana-paylater-sdk": "2.1.0",
+                "indodana/indodana-paylater-sdk": "2.0.1",
                 "respect/validation": "^1.1"
             },
             "require-dev": {
@@ -52,27 +52,26 @@
         },
         {
             "name": "indodana/indodana-paylater-sdk",
-            "version": "2.1.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/indodana-finance/indodana-paylater-sdk-php.git",
-                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f"
+                "reference": "055437ff32f78cc37dee4ae73156feaddb83880a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/indodana-finance/indodana-paylater-sdk-php/zipball/89f6f68885b0162c25f4c1048e1d1932cee9275f",
-                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f",
+                "url": "https://api.github.com/repos/indodana-finance/indodana-paylater-sdk-php/zipball/055437ff32f78cc37dee4ae73156feaddb83880a",
+                "reference": "055437ff32f78cc37dee4ae73156feaddb83880a",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6|^7.0|^8.0"
+                "php": "^5.6|^7.0",
+                "respect/validation": "^1.1"
             },
             "require-dev": {
                 "mockery/mockery": "^1.3",
                 "php-mock/php-mock-mockery": "^1.3",
-                "phpcompatibility/php-compatibility": "^9.3",
-                "phpunit/phpunit": "^5",
-                "squizlabs/php_codesniffer": "^3.6"
+                "phpunit/phpunit": "^5"
             },
             "type": "library",
             "autoload": {
@@ -94,9 +93,9 @@
             "description": "Indodana Paylater SDK for PHP that provides merchant integration functionalities",
             "support": {
                 "issues": "https://github.com/indodana-finance/indodana-paylater-sdk-php/issues",
-                "source": "https://github.com/indodana-finance/indodana-paylater-sdk-php/tree/2.1.0"
+                "source": "https://github.com/indodana-finance/indodana-paylater-sdk-php/tree/2.0.1"
             },
-            "time": "2026-08-14T06:37:44+00:00"
+            "time": "2026-08-14T06:53:39+00:00"
         },
         {
             "name": "respect/validation",

--- a/opencartv2.3/composer.lock
+++ b/opencartv2.3/composer.lock
@@ -8,14 +8,14 @@
     "packages": [
         {
             "name": "indodana/indodana-paylater-ecommerce-common",
-            "version": "dev-master",
+            "version": "dev-bump_sdk_2_1_0_deprecated_api_fix",
             "dist": {
                 "type": "path",
                 "url": "../packages/common",
-                "reference": "0e7294464d80e5e153860560014fc0873ef03090"
+                "reference": "63467d6577f91d902652d15185c998a9bc39fd2f"
             },
             "require": {
-                "indodana/indodana-paylater-sdk": "2.0.0",
+                "indodana/indodana-paylater-sdk": "2.1.0",
                 "respect/validation": "^1.1"
             },
             "require-dev": {
@@ -52,26 +52,27 @@
         },
         {
             "name": "indodana/indodana-paylater-sdk",
-            "version": "2.0.0",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/indodana/indodana-paylater-sdk-php.git",
-                "reference": "f9c044406fa0b34ecec84cbcd2e070d566768ccb"
+                "url": "https://github.com/indodana-finance/indodana-paylater-sdk-php.git",
+                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/indodana/indodana-paylater-sdk-php/zipball/f9c044406fa0b34ecec84cbcd2e070d566768ccb",
-                "reference": "f9c044406fa0b34ecec84cbcd2e070d566768ccb",
+                "url": "https://api.github.com/repos/indodana-finance/indodana-paylater-sdk-php/zipball/89f6f68885b0162c25f4c1048e1d1932cee9275f",
+                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6|^7.0",
-                "respect/validation": "^1.1"
+                "php": "^5.6|^7.0|^8.0"
             },
             "require-dev": {
                 "mockery/mockery": "^1.3",
                 "php-mock/php-mock-mockery": "^1.3",
-                "phpunit/phpunit": "^5"
+                "phpcompatibility/php-compatibility": "^9.3",
+                "phpunit/phpunit": "^5",
+                "squizlabs/php_codesniffer": "^3.6"
             },
             "type": "library",
             "autoload": {
@@ -91,7 +92,11 @@
                 }
             ],
             "description": "Indodana Paylater SDK for PHP that provides merchant integration functionalities",
-            "time": "2020-08-25T12:57:34+00:00"
+            "support": {
+                "issues": "https://github.com/indodana-finance/indodana-paylater-sdk-php/issues",
+                "source": "https://github.com/indodana-finance/indodana-paylater-sdk-php/tree/2.1.0"
+            },
+            "time": "2026-08-14T06:37:44+00:00"
         },
         {
             "name": "respect/validation",
@@ -245,7 +250,7 @@
     },
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/opencartv2/composer.lock
+++ b/opencartv2/composer.lock
@@ -12,10 +12,10 @@
             "dist": {
                 "type": "path",
                 "url": "../packages/common",
-                "reference": "63467d6577f91d902652d15185c998a9bc39fd2f"
+                "reference": "a5e57c150a5bc04ccfd2b46fed5e1f516fdde528"
             },
             "require": {
-                "indodana/indodana-paylater-sdk": "2.1.0",
+                "indodana/indodana-paylater-sdk": "2.0.1",
                 "respect/validation": "^1.1"
             },
             "require-dev": {
@@ -52,27 +52,26 @@
         },
         {
             "name": "indodana/indodana-paylater-sdk",
-            "version": "2.1.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/indodana-finance/indodana-paylater-sdk-php.git",
-                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f"
+                "reference": "055437ff32f78cc37dee4ae73156feaddb83880a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/indodana-finance/indodana-paylater-sdk-php/zipball/89f6f68885b0162c25f4c1048e1d1932cee9275f",
-                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f",
+                "url": "https://api.github.com/repos/indodana-finance/indodana-paylater-sdk-php/zipball/055437ff32f78cc37dee4ae73156feaddb83880a",
+                "reference": "055437ff32f78cc37dee4ae73156feaddb83880a",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6|^7.0|^8.0"
+                "php": "^5.6|^7.0",
+                "respect/validation": "^1.1"
             },
             "require-dev": {
                 "mockery/mockery": "^1.3",
                 "php-mock/php-mock-mockery": "^1.3",
-                "phpcompatibility/php-compatibility": "^9.3",
-                "phpunit/phpunit": "^5",
-                "squizlabs/php_codesniffer": "^3.6"
+                "phpunit/phpunit": "^5"
             },
             "type": "library",
             "autoload": {
@@ -94,9 +93,9 @@
             "description": "Indodana Paylater SDK for PHP that provides merchant integration functionalities",
             "support": {
                 "issues": "https://github.com/indodana-finance/indodana-paylater-sdk-php/issues",
-                "source": "https://github.com/indodana-finance/indodana-paylater-sdk-php/tree/2.1.0"
+                "source": "https://github.com/indodana-finance/indodana-paylater-sdk-php/tree/2.0.1"
             },
-            "time": "2026-08-14T06:37:44+00:00"
+            "time": "2026-08-14T06:53:39+00:00"
         },
         {
             "name": "respect/validation",

--- a/opencartv2/composer.lock
+++ b/opencartv2/composer.lock
@@ -8,14 +8,14 @@
     "packages": [
         {
             "name": "indodana/indodana-paylater-ecommerce-common",
-            "version": "dev-master",
+            "version": "dev-bump_sdk_2_1_0_deprecated_api_fix",
             "dist": {
                 "type": "path",
                 "url": "../packages/common",
-                "reference": "0e7294464d80e5e153860560014fc0873ef03090"
+                "reference": "63467d6577f91d902652d15185c998a9bc39fd2f"
             },
             "require": {
-                "indodana/indodana-paylater-sdk": "2.0.0",
+                "indodana/indodana-paylater-sdk": "2.1.0",
                 "respect/validation": "^1.1"
             },
             "require-dev": {
@@ -52,26 +52,27 @@
         },
         {
             "name": "indodana/indodana-paylater-sdk",
-            "version": "2.0.0",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/indodana/indodana-paylater-sdk-php.git",
-                "reference": "f9c044406fa0b34ecec84cbcd2e070d566768ccb"
+                "url": "https://github.com/indodana-finance/indodana-paylater-sdk-php.git",
+                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/indodana/indodana-paylater-sdk-php/zipball/f9c044406fa0b34ecec84cbcd2e070d566768ccb",
-                "reference": "f9c044406fa0b34ecec84cbcd2e070d566768ccb",
+                "url": "https://api.github.com/repos/indodana-finance/indodana-paylater-sdk-php/zipball/89f6f68885b0162c25f4c1048e1d1932cee9275f",
+                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6|^7.0",
-                "respect/validation": "^1.1"
+                "php": "^5.6|^7.0|^8.0"
             },
             "require-dev": {
                 "mockery/mockery": "^1.3",
                 "php-mock/php-mock-mockery": "^1.3",
-                "phpunit/phpunit": "^5"
+                "phpcompatibility/php-compatibility": "^9.3",
+                "phpunit/phpunit": "^5",
+                "squizlabs/php_codesniffer": "^3.6"
             },
             "type": "library",
             "autoload": {
@@ -91,7 +92,11 @@
                 }
             ],
             "description": "Indodana Paylater SDK for PHP that provides merchant integration functionalities",
-            "time": "2020-08-25T12:57:34+00:00"
+            "support": {
+                "issues": "https://github.com/indodana-finance/indodana-paylater-sdk-php/issues",
+                "source": "https://github.com/indodana-finance/indodana-paylater-sdk-php/tree/2.1.0"
+            },
+            "time": "2026-08-14T06:37:44+00:00"
         },
         {
             "name": "respect/validation",
@@ -309,7 +314,7 @@
     },
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/packages/common/composer.json
+++ b/packages/common/composer.json
@@ -20,7 +20,7 @@
     "test": "./vendor/bin/phpunit --configuration phpunit.xml.dist --testdox --verbose"
   },
   "require": {
-    "indodana/indodana-paylater-sdk": "2.0.0",
+    "indodana/indodana-paylater-sdk": "2.1.0",
     "respect/validation": "^1.1"
   },
   "require-dev": {

--- a/packages/common/composer.json
+++ b/packages/common/composer.json
@@ -20,7 +20,7 @@
     "test": "./vendor/bin/phpunit --configuration phpunit.xml.dist --testdox --verbose"
   },
   "require": {
-    "indodana/indodana-paylater-sdk": "2.1.0",
+    "indodana/indodana-paylater-sdk": "2.0.1",
     "respect/validation": "^1.1"
   },
   "require-dev": {

--- a/packages/common/composer.lock
+++ b/packages/common/composer.lock
@@ -4,31 +4,30 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f3c35715b8ed7f99765601e19fbee8b6",
+    "content-hash": "3c6e1b9d2e5ba14df3be58c0133567cc",
     "packages": [
         {
             "name": "indodana/indodana-paylater-sdk",
-            "version": "2.1.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/indodana-finance/indodana-paylater-sdk-php.git",
-                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f"
+                "reference": "055437ff32f78cc37dee4ae73156feaddb83880a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/indodana-finance/indodana-paylater-sdk-php/zipball/89f6f68885b0162c25f4c1048e1d1932cee9275f",
-                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f",
+                "url": "https://api.github.com/repos/indodana-finance/indodana-paylater-sdk-php/zipball/055437ff32f78cc37dee4ae73156feaddb83880a",
+                "reference": "055437ff32f78cc37dee4ae73156feaddb83880a",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6|^7.0|^8.0"
+                "php": "^5.6|^7.0",
+                "respect/validation": "^1.1"
             },
             "require-dev": {
                 "mockery/mockery": "^1.3",
                 "php-mock/php-mock-mockery": "^1.3",
-                "phpcompatibility/php-compatibility": "^9.3",
-                "phpunit/phpunit": "^5",
-                "squizlabs/php_codesniffer": "^3.6"
+                "phpunit/phpunit": "^5"
             },
             "type": "library",
             "autoload": {
@@ -50,9 +49,9 @@
             "description": "Indodana Paylater SDK for PHP that provides merchant integration functionalities",
             "support": {
                 "issues": "https://github.com/indodana-finance/indodana-paylater-sdk-php/issues",
-                "source": "https://github.com/indodana-finance/indodana-paylater-sdk-php/tree/2.1.0"
+                "source": "https://github.com/indodana-finance/indodana-paylater-sdk-php/tree/2.0.1"
             },
-            "time": "2026-08-14T06:37:44+00:00"
+            "time": "2026-08-14T06:53:39+00:00"
         },
         {
             "name": "respect/validation",

--- a/packages/common/composer.lock
+++ b/packages/common/composer.lock
@@ -4,30 +4,31 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ae8d8cb26dfd1e0d21ad470639915c90",
+    "content-hash": "f3c35715b8ed7f99765601e19fbee8b6",
     "packages": [
         {
             "name": "indodana/indodana-paylater-sdk",
-            "version": "2.0.0",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/indodana/indodana-paylater-sdk-php.git",
-                "reference": "f9c044406fa0b34ecec84cbcd2e070d566768ccb"
+                "url": "https://github.com/indodana-finance/indodana-paylater-sdk-php.git",
+                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/indodana/indodana-paylater-sdk-php/zipball/f9c044406fa0b34ecec84cbcd2e070d566768ccb",
-                "reference": "f9c044406fa0b34ecec84cbcd2e070d566768ccb",
+                "url": "https://api.github.com/repos/indodana-finance/indodana-paylater-sdk-php/zipball/89f6f68885b0162c25f4c1048e1d1932cee9275f",
+                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6|^7.0",
-                "respect/validation": "^1.1"
+                "php": "^5.6|^7.0|^8.0"
             },
             "require-dev": {
                 "mockery/mockery": "^1.3",
                 "php-mock/php-mock-mockery": "^1.3",
-                "phpunit/phpunit": "^5"
+                "phpcompatibility/php-compatibility": "^9.3",
+                "phpunit/phpunit": "^5",
+                "squizlabs/php_codesniffer": "^3.6"
             },
             "type": "library",
             "autoload": {
@@ -47,7 +48,11 @@
                 }
             ],
             "description": "Indodana Paylater SDK for PHP that provides merchant integration functionalities",
-            "time": "2020-08-25T12:57:34+00:00"
+            "support": {
+                "issues": "https://github.com/indodana-finance/indodana-paylater-sdk-php/issues",
+                "source": "https://github.com/indodana-finance/indodana-paylater-sdk-php/tree/2.1.0"
+            },
+            "time": "2026-08-14T06:37:44+00:00"
         },
         {
             "name": "respect/validation",
@@ -1896,10 +1901,10 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/prestashopv1/composer.lock
+++ b/prestashopv1/composer.lock
@@ -12,10 +12,10 @@
             "dist": {
                 "type": "path",
                 "url": "../packages/common",
-                "reference": "63467d6577f91d902652d15185c998a9bc39fd2f"
+                "reference": "a5e57c150a5bc04ccfd2b46fed5e1f516fdde528"
             },
             "require": {
-                "indodana/indodana-paylater-sdk": "2.1.0",
+                "indodana/indodana-paylater-sdk": "2.0.1",
                 "respect/validation": "^1.1"
             },
             "require-dev": {
@@ -52,27 +52,26 @@
         },
         {
             "name": "indodana/indodana-paylater-sdk",
-            "version": "2.1.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/indodana-finance/indodana-paylater-sdk-php.git",
-                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f"
+                "reference": "055437ff32f78cc37dee4ae73156feaddb83880a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/indodana-finance/indodana-paylater-sdk-php/zipball/89f6f68885b0162c25f4c1048e1d1932cee9275f",
-                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f",
+                "url": "https://api.github.com/repos/indodana-finance/indodana-paylater-sdk-php/zipball/055437ff32f78cc37dee4ae73156feaddb83880a",
+                "reference": "055437ff32f78cc37dee4ae73156feaddb83880a",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6|^7.0|^8.0"
+                "php": "^5.6|^7.0",
+                "respect/validation": "^1.1"
             },
             "require-dev": {
                 "mockery/mockery": "^1.3",
                 "php-mock/php-mock-mockery": "^1.3",
-                "phpcompatibility/php-compatibility": "^9.3",
-                "phpunit/phpunit": "^5",
-                "squizlabs/php_codesniffer": "^3.6"
+                "phpunit/phpunit": "^5"
             },
             "type": "library",
             "autoload": {
@@ -94,9 +93,9 @@
             "description": "Indodana Paylater SDK for PHP that provides merchant integration functionalities",
             "support": {
                 "issues": "https://github.com/indodana-finance/indodana-paylater-sdk-php/issues",
-                "source": "https://github.com/indodana-finance/indodana-paylater-sdk-php/tree/2.1.0"
+                "source": "https://github.com/indodana-finance/indodana-paylater-sdk-php/tree/2.0.1"
             },
-            "time": "2026-08-14T06:37:44+00:00"
+            "time": "2026-08-14T06:53:39+00:00"
         },
         {
             "name": "respect/validation",

--- a/prestashopv1/composer.lock
+++ b/prestashopv1/composer.lock
@@ -8,14 +8,14 @@
     "packages": [
         {
             "name": "indodana/indodana-paylater-ecommerce-common",
-            "version": "dev-master",
+            "version": "dev-bump_sdk_2_1_0_deprecated_api_fix",
             "dist": {
                 "type": "path",
                 "url": "../packages/common",
-                "reference": "0e7294464d80e5e153860560014fc0873ef03090"
+                "reference": "63467d6577f91d902652d15185c998a9bc39fd2f"
             },
             "require": {
-                "indodana/indodana-paylater-sdk": "2.0.0",
+                "indodana/indodana-paylater-sdk": "2.1.0",
                 "respect/validation": "^1.1"
             },
             "require-dev": {
@@ -52,26 +52,27 @@
         },
         {
             "name": "indodana/indodana-paylater-sdk",
-            "version": "2.0.0",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/indodana/indodana-paylater-sdk-php.git",
-                "reference": "f9c044406fa0b34ecec84cbcd2e070d566768ccb"
+                "url": "https://github.com/indodana-finance/indodana-paylater-sdk-php.git",
+                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/indodana/indodana-paylater-sdk-php/zipball/f9c044406fa0b34ecec84cbcd2e070d566768ccb",
-                "reference": "f9c044406fa0b34ecec84cbcd2e070d566768ccb",
+                "url": "https://api.github.com/repos/indodana-finance/indodana-paylater-sdk-php/zipball/89f6f68885b0162c25f4c1048e1d1932cee9275f",
+                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6|^7.0",
-                "respect/validation": "^1.1"
+                "php": "^5.6|^7.0|^8.0"
             },
             "require-dev": {
                 "mockery/mockery": "^1.3",
                 "php-mock/php-mock-mockery": "^1.3",
-                "phpunit/phpunit": "^5"
+                "phpcompatibility/php-compatibility": "^9.3",
+                "phpunit/phpunit": "^5",
+                "squizlabs/php_codesniffer": "^3.6"
             },
             "type": "library",
             "autoload": {
@@ -91,7 +92,11 @@
                 }
             ],
             "description": "Indodana Paylater SDK for PHP that provides merchant integration functionalities",
-            "time": "2020-08-25T12:57:34+00:00"
+            "support": {
+                "issues": "https://github.com/indodana-finance/indodana-paylater-sdk-php/issues",
+                "source": "https://github.com/indodana-finance/indodana-paylater-sdk-php/tree/2.1.0"
+            },
+            "time": "2026-08-14T06:37:44+00:00"
         },
         {
             "name": "respect/validation",
@@ -245,7 +250,7 @@
     },
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/woocommerce/composer.lock
+++ b/woocommerce/composer.lock
@@ -442,14 +442,14 @@
         },
         {
             "name": "indodana/indodana-paylater-ecommerce-common",
-            "version": "dev-master",
+            "version": "dev-bump_sdk_2_1_0_deprecated_api_fix",
             "dist": {
                 "type": "path",
                 "url": "../packages/common",
-                "reference": "0e7294464d80e5e153860560014fc0873ef03090"
+                "reference": "63467d6577f91d902652d15185c998a9bc39fd2f"
             },
             "require": {
-                "indodana/indodana-paylater-sdk": "2.0.0",
+                "indodana/indodana-paylater-sdk": "2.1.0",
                 "respect/validation": "^1.1"
             },
             "require-dev": {
@@ -486,26 +486,27 @@
         },
         {
             "name": "indodana/indodana-paylater-sdk",
-            "version": "2.0.0",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/indodana/indodana-paylater-sdk-php.git",
-                "reference": "f9c044406fa0b34ecec84cbcd2e070d566768ccb"
+                "url": "https://github.com/indodana-finance/indodana-paylater-sdk-php.git",
+                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/indodana/indodana-paylater-sdk-php/zipball/f9c044406fa0b34ecec84cbcd2e070d566768ccb",
-                "reference": "f9c044406fa0b34ecec84cbcd2e070d566768ccb",
+                "url": "https://api.github.com/repos/indodana-finance/indodana-paylater-sdk-php/zipball/89f6f68885b0162c25f4c1048e1d1932cee9275f",
+                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6|^7.0",
-                "respect/validation": "^1.1"
+                "php": "^5.6|^7.0|^8.0"
             },
             "require-dev": {
                 "mockery/mockery": "^1.3",
                 "php-mock/php-mock-mockery": "^1.3",
-                "phpunit/phpunit": "^5"
+                "phpcompatibility/php-compatibility": "^9.3",
+                "phpunit/phpunit": "^5",
+                "squizlabs/php_codesniffer": "^3.6"
             },
             "type": "library",
             "autoload": {
@@ -525,7 +526,11 @@
                 }
             ],
             "description": "Indodana Paylater SDK for PHP that provides merchant integration functionalities",
-            "time": "2020-08-25T12:57:34+00:00"
+            "support": {
+                "issues": "https://github.com/indodana-finance/indodana-paylater-sdk-php/issues",
+                "source": "https://github.com/indodana-finance/indodana-paylater-sdk-php/tree/2.1.0"
+            },
+            "time": "2026-08-14T06:37:44+00:00"
         },
         {
             "name": "jean85/pretty-package-versions",
@@ -2130,7 +2135,7 @@
     },
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/woocommerce/composer.lock
+++ b/woocommerce/composer.lock
@@ -446,10 +446,10 @@
             "dist": {
                 "type": "path",
                 "url": "../packages/common",
-                "reference": "63467d6577f91d902652d15185c998a9bc39fd2f"
+                "reference": "a5e57c150a5bc04ccfd2b46fed5e1f516fdde528"
             },
             "require": {
-                "indodana/indodana-paylater-sdk": "2.1.0",
+                "indodana/indodana-paylater-sdk": "2.0.1",
                 "respect/validation": "^1.1"
             },
             "require-dev": {
@@ -486,27 +486,26 @@
         },
         {
             "name": "indodana/indodana-paylater-sdk",
-            "version": "2.1.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/indodana-finance/indodana-paylater-sdk-php.git",
-                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f"
+                "reference": "055437ff32f78cc37dee4ae73156feaddb83880a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/indodana-finance/indodana-paylater-sdk-php/zipball/89f6f68885b0162c25f4c1048e1d1932cee9275f",
-                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f",
+                "url": "https://api.github.com/repos/indodana-finance/indodana-paylater-sdk-php/zipball/055437ff32f78cc37dee4ae73156feaddb83880a",
+                "reference": "055437ff32f78cc37dee4ae73156feaddb83880a",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6|^7.0|^8.0"
+                "php": "^5.6|^7.0",
+                "respect/validation": "^1.1"
             },
             "require-dev": {
                 "mockery/mockery": "^1.3",
                 "php-mock/php-mock-mockery": "^1.3",
-                "phpcompatibility/php-compatibility": "^9.3",
-                "phpunit/phpunit": "^5",
-                "squizlabs/php_codesniffer": "^3.6"
+                "phpunit/phpunit": "^5"
             },
             "type": "library",
             "autoload": {
@@ -528,9 +527,9 @@
             "description": "Indodana Paylater SDK for PHP that provides merchant integration functionalities",
             "support": {
                 "issues": "https://github.com/indodana-finance/indodana-paylater-sdk-php/issues",
-                "source": "https://github.com/indodana-finance/indodana-paylater-sdk-php/tree/2.1.0"
+                "source": "https://github.com/indodana-finance/indodana-paylater-sdk-php/tree/2.0.1"
             },
-            "time": "2026-08-14T06:37:44+00:00"
+            "time": "2026-08-14T06:53:39+00:00"
         },
         {
             "name": "jean85/pretty-package-versions",

--- a/woocommercev4/composer.lock
+++ b/woocommercev4/composer.lock
@@ -442,14 +442,14 @@
         },
         {
             "name": "indodana/indodana-paylater-ecommerce-common",
-            "version": "dev-master",
+            "version": "dev-bump_sdk_2_1_0_deprecated_api_fix",
             "dist": {
                 "type": "path",
                 "url": "../packages/common",
-                "reference": "0e7294464d80e5e153860560014fc0873ef03090"
+                "reference": "63467d6577f91d902652d15185c998a9bc39fd2f"
             },
             "require": {
-                "indodana/indodana-paylater-sdk": "2.0.0",
+                "indodana/indodana-paylater-sdk": "2.1.0",
                 "respect/validation": "^1.1"
             },
             "require-dev": {
@@ -486,26 +486,27 @@
         },
         {
             "name": "indodana/indodana-paylater-sdk",
-            "version": "2.0.0",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/indodana/indodana-paylater-sdk-php.git",
-                "reference": "f9c044406fa0b34ecec84cbcd2e070d566768ccb"
+                "url": "https://github.com/indodana-finance/indodana-paylater-sdk-php.git",
+                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/indodana/indodana-paylater-sdk-php/zipball/f9c044406fa0b34ecec84cbcd2e070d566768ccb",
-                "reference": "f9c044406fa0b34ecec84cbcd2e070d566768ccb",
+                "url": "https://api.github.com/repos/indodana-finance/indodana-paylater-sdk-php/zipball/89f6f68885b0162c25f4c1048e1d1932cee9275f",
+                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6|^7.0",
-                "respect/validation": "^1.1"
+                "php": "^5.6|^7.0|^8.0"
             },
             "require-dev": {
                 "mockery/mockery": "^1.3",
                 "php-mock/php-mock-mockery": "^1.3",
-                "phpunit/phpunit": "^5"
+                "phpcompatibility/php-compatibility": "^9.3",
+                "phpunit/phpunit": "^5",
+                "squizlabs/php_codesniffer": "^3.6"
             },
             "type": "library",
             "autoload": {
@@ -525,7 +526,11 @@
                 }
             ],
             "description": "Indodana Paylater SDK for PHP that provides merchant integration functionalities",
-            "time": "2020-08-25T12:57:34+00:00"
+            "support": {
+                "issues": "https://github.com/indodana-finance/indodana-paylater-sdk-php/issues",
+                "source": "https://github.com/indodana-finance/indodana-paylater-sdk-php/tree/2.1.0"
+            },
+            "time": "2026-08-14T06:37:44+00:00"
         },
         {
             "name": "jean85/pretty-package-versions",
@@ -2130,7 +2135,7 @@
     },
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }

--- a/woocommercev4/composer.lock
+++ b/woocommercev4/composer.lock
@@ -446,10 +446,10 @@
             "dist": {
                 "type": "path",
                 "url": "../packages/common",
-                "reference": "63467d6577f91d902652d15185c998a9bc39fd2f"
+                "reference": "a5e57c150a5bc04ccfd2b46fed5e1f516fdde528"
             },
             "require": {
-                "indodana/indodana-paylater-sdk": "2.1.0",
+                "indodana/indodana-paylater-sdk": "2.0.1",
                 "respect/validation": "^1.1"
             },
             "require-dev": {
@@ -486,27 +486,26 @@
         },
         {
             "name": "indodana/indodana-paylater-sdk",
-            "version": "2.1.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/indodana-finance/indodana-paylater-sdk-php.git",
-                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f"
+                "reference": "055437ff32f78cc37dee4ae73156feaddb83880a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/indodana-finance/indodana-paylater-sdk-php/zipball/89f6f68885b0162c25f4c1048e1d1932cee9275f",
-                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f",
+                "url": "https://api.github.com/repos/indodana-finance/indodana-paylater-sdk-php/zipball/055437ff32f78cc37dee4ae73156feaddb83880a",
+                "reference": "055437ff32f78cc37dee4ae73156feaddb83880a",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6|^7.0|^8.0"
+                "php": "^5.6|^7.0",
+                "respect/validation": "^1.1"
             },
             "require-dev": {
                 "mockery/mockery": "^1.3",
                 "php-mock/php-mock-mockery": "^1.3",
-                "phpcompatibility/php-compatibility": "^9.3",
-                "phpunit/phpunit": "^5",
-                "squizlabs/php_codesniffer": "^3.6"
+                "phpunit/phpunit": "^5"
             },
             "type": "library",
             "autoload": {
@@ -528,9 +527,9 @@
             "description": "Indodana Paylater SDK for PHP that provides merchant integration functionalities",
             "support": {
                 "issues": "https://github.com/indodana-finance/indodana-paylater-sdk-php/issues",
-                "source": "https://github.com/indodana-finance/indodana-paylater-sdk-php/tree/2.1.0"
+                "source": "https://github.com/indodana-finance/indodana-paylater-sdk-php/tree/2.0.1"
             },
-            "time": "2026-08-14T06:37:44+00:00"
+            "time": "2026-08-14T06:53:39+00:00"
         },
         {
             "name": "jean85/pretty-package-versions",

--- a/woocommercev5/composer.lock
+++ b/woocommercev5/composer.lock
@@ -449,10 +449,10 @@
             "dist": {
                 "type": "path",
                 "url": "../packages/common",
-                "reference": "63467d6577f91d902652d15185c998a9bc39fd2f"
+                "reference": "a5e57c150a5bc04ccfd2b46fed5e1f516fdde528"
             },
             "require": {
-                "indodana/indodana-paylater-sdk": "2.1.0",
+                "indodana/indodana-paylater-sdk": "2.0.1",
                 "respect/validation": "^1.1"
             },
             "require-dev": {
@@ -489,27 +489,26 @@
         },
         {
             "name": "indodana/indodana-paylater-sdk",
-            "version": "2.1.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/indodana-finance/indodana-paylater-sdk-php.git",
-                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f"
+                "reference": "055437ff32f78cc37dee4ae73156feaddb83880a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/indodana-finance/indodana-paylater-sdk-php/zipball/89f6f68885b0162c25f4c1048e1d1932cee9275f",
-                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f",
+                "url": "https://api.github.com/repos/indodana-finance/indodana-paylater-sdk-php/zipball/055437ff32f78cc37dee4ae73156feaddb83880a",
+                "reference": "055437ff32f78cc37dee4ae73156feaddb83880a",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6|^7.0|^8.0"
+                "php": "^5.6|^7.0",
+                "respect/validation": "^1.1"
             },
             "require-dev": {
                 "mockery/mockery": "^1.3",
                 "php-mock/php-mock-mockery": "^1.3",
-                "phpcompatibility/php-compatibility": "^9.3",
-                "phpunit/phpunit": "^5",
-                "squizlabs/php_codesniffer": "^3.6"
+                "phpunit/phpunit": "^5"
             },
             "type": "library",
             "autoload": {
@@ -531,9 +530,9 @@
             "description": "Indodana Paylater SDK for PHP that provides merchant integration functionalities",
             "support": {
                 "issues": "https://github.com/indodana-finance/indodana-paylater-sdk-php/issues",
-                "source": "https://github.com/indodana-finance/indodana-paylater-sdk-php/tree/2.1.0"
+                "source": "https://github.com/indodana-finance/indodana-paylater-sdk-php/tree/2.0.1"
             },
-            "time": "2026-08-14T06:37:44+00:00"
+            "time": "2026-08-14T06:53:39+00:00"
         },
         {
             "name": "jean85/pretty-package-versions",

--- a/woocommercev5/composer.lock
+++ b/woocommercev5/composer.lock
@@ -445,14 +445,14 @@
         },
         {
             "name": "indodana/indodana-paylater-ecommerce-common",
-            "version": "dev-master",
+            "version": "dev-bump_sdk_2_1_0_deprecated_api_fix",
             "dist": {
                 "type": "path",
                 "url": "../packages/common",
-                "reference": "0e7294464d80e5e153860560014fc0873ef03090"
+                "reference": "63467d6577f91d902652d15185c998a9bc39fd2f"
             },
             "require": {
-                "indodana/indodana-paylater-sdk": "2.0.0",
+                "indodana/indodana-paylater-sdk": "2.1.0",
                 "respect/validation": "^1.1"
             },
             "require-dev": {
@@ -489,26 +489,27 @@
         },
         {
             "name": "indodana/indodana-paylater-sdk",
-            "version": "2.0.0",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/indodana/indodana-paylater-sdk-php.git",
-                "reference": "f9c044406fa0b34ecec84cbcd2e070d566768ccb"
+                "url": "https://github.com/indodana-finance/indodana-paylater-sdk-php.git",
+                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/indodana/indodana-paylater-sdk-php/zipball/f9c044406fa0b34ecec84cbcd2e070d566768ccb",
-                "reference": "f9c044406fa0b34ecec84cbcd2e070d566768ccb",
+                "url": "https://api.github.com/repos/indodana-finance/indodana-paylater-sdk-php/zipball/89f6f68885b0162c25f4c1048e1d1932cee9275f",
+                "reference": "89f6f68885b0162c25f4c1048e1d1932cee9275f",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6|^7.0",
-                "respect/validation": "^1.1"
+                "php": "^5.6|^7.0|^8.0"
             },
             "require-dev": {
                 "mockery/mockery": "^1.3",
                 "php-mock/php-mock-mockery": "^1.3",
-                "phpunit/phpunit": "^5"
+                "phpcompatibility/php-compatibility": "^9.3",
+                "phpunit/phpunit": "^5",
+                "squizlabs/php_codesniffer": "^3.6"
             },
             "type": "library",
             "autoload": {
@@ -528,7 +529,11 @@
                 }
             ],
             "description": "Indodana Paylater SDK for PHP that provides merchant integration functionalities",
-            "time": "2020-08-25T12:57:34+00:00"
+            "support": {
+                "issues": "https://github.com/indodana-finance/indodana-paylater-sdk-php/issues",
+                "source": "https://github.com/indodana-finance/indodana-paylater-sdk-php/tree/2.1.0"
+            },
+            "time": "2026-08-14T06:37:44+00:00"
         },
         {
             "name": "jean85/pretty-package-versions",
@@ -2133,7 +2138,7 @@
     },
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
Uses SDK **2.0.1** (`indodana-paylater-sdk-php` branch `release/2.0.x`, tag `055437f`, live on Packagist).

## Why

SDK 2.0.0 calls `POST /v1/payment_calculation`. chermes sunset that endpoint on **2025-11-10** (`src/api/routes/merchant.js:73` + `src/common/middlewares/scheduled-deprecation.js:44-50`): past the timestamp, any merchant not in the `merchant-accessing-v1paymentcalculation-and-v1-checkouturl` whitelist gets `HTTP 404 "Not found - API deprecated"`.

That call decides whether Indodana appears as a payment method at all, so **every non-whitelisted merchant on every platform has been silently losing it** for nine months. Grandfathered merchants still work, which is why it presents as intermittent and won't reproduce on a whitelisted test account.

## Why 2.0.1 and not 2.1.0

This branch originally bumped to **2.1.0**. CI caught that 2.1.0 is unusable here:

```
PHP Fatal error: Class 'Indodana\RespectValidation\RespectValidationHelper' not found
  in packages/common/src/Seller.php on line 19
```

2.1.0 was cut from the SDK's `master`, which had absorbed the removal of `src/RespectValidation/` in favour of `src/Utils/Validator/Validator.php`, and dropped `respect/validation` from `require`. `packages/common` still calls `RespectValidationHelper::validate()` from `Seller.php:19`, `Order.php:38` and `IndodanaService.php:7`. Adapting to the new validator is what **#47** exists for — its SDK-side blocker has now landed, but it's a 19-file refactor from 2022 that predates #60 and #61 and needs its own rebase and review.

So **2.0.1** is a maintenance release branched from tag `2.0.0` carrying *only* the endpoint change:

| | 2.0.0 | **2.0.1** | 2.1.0 |
|---|---|---|---|
| `payment_calculation` | `/v1` ❌ sunset | **`/v2`** ✅ | `/v2` ✅ |
| `order_cancellation` | `/v2` | **`/v3`** | `/v3` |
| `src/RespectValidation/` | present | **present** | ❌ removed |
| `respect/validation` dep | required | **required** | ❌ dropped |
| `php` constraint | `^5.6\|^7.0` | **`^5.6\|^7.0`** | `^5.6\|^7.0\|^8.0` |

Drop-in for every plugin currently on 2.0.0.

## Changes

- `packages/common/composer.json`: pin `2.0.0` → `2.0.1`
- Regenerated `composer.lock` in **all ten plugin directories** plus `packages/common`
- **`release.yml` untouched.** Because 2.0.1 keeps `"php": "^5.6|^7.0"`, the `--ignore-platform-req=php` workaround from #61 must stay for the PHP 8.1 `magentov2.4.4` build. An earlier revision of this branch removed it; that has been reverted.

## Verification

On PHP 7.4 with Composer 2.10.2:

- `composer update` targeted only the `indodana/*` packages. Across all eleven locks, **no other package was added, removed or version-changed**
- **`packages/common` test suite passes locally: `OK (59 tests, 145 assertions)`** — the exact suite that produced the fatal on 2.1.0
- CI green on this branch (47s / 56s, suite genuinely executing)
- `composer validate` clean on all eleven manifests (only pre-existing `@dev` / exact-pin style warnings)
- `make magentov2.4.4-build` succeeds and the built tree confirms both the fix and the retained classes:
  ```
  .build/magentov2.4.4/…/vendor/indodana/indodana-paylater-sdk/src/
    Indodana.php:76   $url = $this->urlPath('/v2/payment_calculation');   ← was /v1
    Indodana.php:109  $url = $this->urlPath('/v3/order_cancellation');    ← was /v2
    RespectValidation/RespectValidationHelper.php                          ← still shipped
  ```
- Both vendored `indodana/*` directories are real directories in the build output, confirming `cp -Lr` dereferenced the path-repo symlink

**Not verified:** a live checkout against chermes `/v2/payment_calculation`, which needs the docker harness and merchant credentials. That belongs in the staging test round.

## Lock churn worth a glance

`indodana/…-ecommerce-common` is a path repo with no `version` field, so Composer records the **current git branch** as its dev version — hence `dev-fix_github_actions_release` → `dev-bump_sdk_2_1_0_deprecated_api_fix` in every lock. Cosmetic (path repos resolve locally regardless), and the old value was itself a long-deleted branch. Adding an explicit `"version"` to `packages/common/composer.json` would stop the churn.

`plugin-api-version` moves `1.1.0` → `2.9.0` because these locks were originally generated by Composer 1 and are now regenerated by Composer 2. CI installs Composer 2, so this is the more correct format.

## ⚠️ This does not reach merchants by itself

The SDK is vendored into the release zip at build time, so nothing pushes this to existing installs. **Every plugin needs its own release tag**, and each merchant must re-download and reinstall:

| Plugin | Tag prefix |
|---|---|
| `magentov2.4.4` | `MagentoV2.4.4-` ← in flight |
| `magentov2.4.0` | `MagentoV2.4.0-` |
| `magento1` | `MagentoV1-` |
| `woocommerce` / `v4` / `v5` | `WoocommerceV3-` / `V4-` / `V5-` |
| `opencartv1` / `v2` / `v2.3` | `OpencartV1-` / `V2-` / `V2.3-` |
| `prestashopv1` | `PrestashopV1-` |

If the 404 is hurting live merchants now, the fastest mitigation is adding them to the chermes `merchant-accessing-v1paymentcalculation-and-v1-checkouturl` whitelist while these releases roll out.

## Follow-ups

1. **#47** — rebase and land it, then the SDK can move to 2.1.0. That also drops `respect/validation` entirely, which removes `Rules/NfeAccessKey.php` and its PHP-8-invalid curly-brace offsets (flagged on #61), and lets the `--ignore-platform-req=php` workaround go.
2. `checkTransactionStatus()` still uses `/v1/transactions/check_status`. Not deprecated, so nothing is broken, but v2 exists with the same middleware chain.
